### PR TITLE
Add infrastructure label to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,5 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - dependencies
+      - infrastructure
 


### PR DESCRIPTION
This adds the infrastructure label to dependabot PRs for GitHub actions workflows.